### PR TITLE
Fixed provided config object overridden by default options

### DIFF
--- a/src/bitly.js
+++ b/src/bitly.js
@@ -18,12 +18,12 @@ class Bitly {
   constructor (accessToken, config) {
 
     // Set up the config for requests being made with the instance of this
-    this.config = Object.assign({ access_token: accessToken }, config, {
+    this.config = Object.assign({ access_token: accessToken }, {
       format: 'json',
       api_url: 'api-ssl.bitly.com',
       api_version: 'v3',
       domain: 'bit.ly'
-    });
+    }, config);
   }
 
 


### PR DESCRIPTION
Fixes a problem where default settings override any provided configuration object.

For example, when I tried to change custom domain I still received links with default bit.ly domain

```
var bitly = Bitly( URL, { domain: 'my.customdomain.com' }) // then will still have http://bit.ly/XXXXX 
```

P. S. Moreover, according to bit.ly spec `format` and `domain` are optional properties. Bit.ly will use `json`  by default for `format`, and for `domain` it will use a default domain specified in bit.ly's settings.
